### PR TITLE
feat(ai-sme): Create reusable color system and template

### DIFF
--- a/ai-sme/index.html
+++ b/ai-sme/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../shared/ai-sme-colors.css">
     <script>
         tailwind.config = {
             theme: {
@@ -16,33 +17,37 @@
                         sans: ['Inter', 'sans-serif'],
                     },
                     colors: {
-                        'brand-primary': '#2563EB', // Blue 600
-                        'brand-primary-hover': '#1D4ED8', // Blue 700
-                        'brand-dark': '#111827', // Gray 900
-                        'brand-body': '#374151', // Gray 700
-                        'brand-muted': '#6B7280', // Gray 500
-                        'brand-bg': '#F9FAFB', // Gray 50
-                        'brand-card-bg': '#FFFFFF',
+                        'brand-primary': 'var(--ai-accent)',
+                        'brand-primary-hover': 'var(--ai-accent-hover)',
+                        'brand-dark': 'var(--ai-heading)',
+                        'brand-body': 'var(--ai-text)',
+                        'brand-muted': 'var(--ai-text)', // Using main text color for muted as well for simplicity
+                        'brand-bg': 'var(--ai-bg)',
+                        'brand-card-bg': 'var(--ai-card)',
                     }
                 }
             }
         }
     </script>
     <style>
+        body {
+            background-color: var(--ai-bg);
+            color: var(--ai-text);
+        }
         .nav-link.active {
-            color: #2563EB; /* brand-primary */
+            color: var(--ai-accent);
             font-weight: 600;
         }
         .section-title {
             font-size: 2.25rem;
             font-weight: 700;
-            color: #111827; /* brand-dark */
+            color: var(--ai-heading);
             margin-bottom: 1rem;
             text-align: center;
         }
         .section-subtitle {
             font-size: 1.125rem;
-            color: #6B7280; /* brand-muted */
+            color: var(--ai-text);
             text-align: center;
             max-width: 42rem; /* 3xl */
             margin-left: auto;
@@ -50,16 +55,16 @@
             margin-bottom: 3rem;
         }
         .card {
-            background-color: #FFFFFF; /* brand-card-bg */
+            background-color: var(--ai-card);
             border-radius: 0.75rem; /* larger radius */
             padding: 1.5rem;
             transition: transform 0.3s ease, box-shadow 0.3s ease;
-            border: 1px solid #E5E7EB; /* Gray 200 */
-            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+            border: 1px solid var(--ai-border);
+            box-shadow: var(--ai-shadow-sm);
         }
         .card:hover {
             transform: translateY(-5px);
-            box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+            box-shadow: var(--ai-shadow-md);
         }
         .btn {
             display: inline-block;
@@ -70,19 +75,20 @@
             transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
         }
         .btn-primary {
-            background-color: #2563EB; /* brand-primary */
+            background-color: var(--ai-accent);
             color: white;
         }
         .btn-primary:hover {
-            background-color: #1D4ED8; /* brand-primary-hover */
+            background-color: var(--ai-accent-hover);
         }
         .btn-secondary {
             background-color: transparent;
-            color: #2563EB; /* brand-primary */
-            border: 1px solid #2563EB; /* brand-primary */
+            color: var(--ai-accent);
+            border: 1px solid var(--ai-accent);
         }
         .btn-secondary:hover {
-            background-color: #DBEAFE; /* Blue 100 */
+            background-color: var(--ai-accent);
+            color: white;
         }
         .btn-lg {
             padding: 1rem 2rem;

--- a/ai-sme/new-page-template.html
+++ b/ai-sme/new-page-template.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Page Template - AI Horizon</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <!-- Link to the shared color palette -->
+    <link rel="stylesheet" href="../../shared/ai-sme-colors.css">
+    <script>
+        // Tailwind config using the new CSS variables
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        'brand-primary': 'var(--ai-accent)',
+                        'brand-primary-hover': 'var(--ai-accent-hover)',
+                        'brand-dark': 'var(--ai-heading)',
+                        'brand-body': 'var(--ai-text)',
+                        'brand-muted': 'var(--ai-text)',
+                        'brand-bg': 'var(--ai-bg)',
+                        'brand-card-bg': 'var(--ai-card)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        /* You can add page-specific styles here if needed */
+        body {
+            background-color: var(--ai-bg);
+            color: var(--ai-text);
+        }
+    </style>
+</head>
+<body class="bg-brand-bg text-brand-body font-sans leading-relaxed">
+
+    <!-- Header & Navigation (Consistent with index.html) -->
+    <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-50 transition-all duration-300 shadow-sm">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="index.html" class="text-2xl font-bold text-brand-dark flex items-center">
+                <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2 text-brand-primary"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5"></path><path d="M2 12l10 5 10-5"></path></svg>
+                AI Horizon
+            </a>
+            <nav class="hidden md:flex items-center space-x-8">
+                <a href="index.html#home" class="text-brand-body hover:text-brand-primary transition-colors duration-300">Home</a>
+                <a href="index.html#get-started" class="text-brand-body hover:text-brand-primary transition-colors duration-300">Get Started</a>
+                <a href="index.html#learning-hub" class="text-brand-body hover:text-brand-primary transition-colors duration-300">Learning Hub</a>
+            </nav>
+            <a href="index.html#community" class="hidden md:inline-block btn-ai-primary">Get Help</a>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 md:py-20">
+
+        <section>
+            <h1 class="text-4xl md:text-5xl font-extrabold text-ai-heading mb-4">New Page Title</h1>
+            <p class="text-lg md:text-xl text-ai-text mb-8">
+                This is a template for creating new pages. It uses the shared color palette from
+                <code class="bg-gray-200 text-sm p-1 rounded">shared/ai-sme-colors.css</code>.
+                Below are examples of how to apply the new styles.
+            </p>
+
+            <div class="space-y-12">
+                <!-- Text and Headings -->
+                <div>
+                    <h2 class="text-3xl font-bold text-ai-heading border-b border-ai-border pb-2 mb-4">Text and Headings</h2>
+                    <p class="text-ai-text mb-4">This is a standard paragraph using <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-text</code>. The main text color is <span style="color:var(--ai-text)">#4A4A4A</span>.</p>
+                    <h3 class="text-2xl font-bold text-ai-heading mb-2">This is a Sub-Heading (h3)</h3>
+                    <p class="text-ai-text mb-4">Headings use <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-heading</code>, which is <span style="color:var(--ai-heading)">#111827</span>.</p>
+                    <a href="#" class="text-ai-accent hover:underline">This is a link using .text-ai-accent</a>
+                </div>
+
+                <!-- Buttons -->
+                <div>
+                    <h2 class="text-3xl font-bold text-ai-heading border-b border-ai-border pb-2 mb-4">Buttons</h2>
+                    <div class="flex flex-wrap gap-4 items-center">
+                        <button class="btn-ai-primary">Primary Button</button>
+                        <button class="btn-ai-secondary">Secondary Button</button>
+                        <p class="text-ai-text">Use classes <code class="bg-gray-200 text-sm p-1 rounded">.btn-ai-primary</code> and <code class="bg-gray-200 text-sm p-1 rounded">.btn-ai-secondary</code>.</p>
+                    </div>
+                </div>
+
+                <!-- Cards -->
+                <div>
+                    <h2 class="text-3xl font-bold text-ai-heading border-b border-ai-border pb-2 mb-4">Cards</h2>
+                    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <div class="card-ai">
+                            <h3 class="text-xl font-bold text-ai-heading mb-2">Standard Card</h3>
+                            <p class="text-ai-text">This card uses the <code class="bg-gray-200 text-sm p-1 rounded">.card-ai</code> class from the shared CSS file. It includes background color, padding, border, radius, and shadow effects.</p>
+                        </div>
+                        <div class="card-ai">
+                            <h3 class="text-xl font-bold text-ai-heading mb-2">Another Card</h3>
+                            <p class="text-ai-text">Just by reusing the <code class="bg-gray-200 text-sm p-1 rounded">.card-ai</code> class, you get a consistent look and feel across all card elements on the site.</p>
+                        </div>
+                        <div class="bg-ai-card p-6 rounded-lg border border-ai-border shadow-ai-sm">
+                             <h3 class="text-xl font-bold text-ai-heading mb-2">Manual Card</h3>
+                            <p class="text-ai-text">You can also construct cards manually using utility classes with the color variables, but the pre-built class is easier.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </section>
+
+    </main>
+
+    <!-- Footer (Consistent with index.html) -->
+    <footer class="bg-white border-t border-gray-200 mt-20">
+        <div class="container mx-auto px-6 py-8 text-center" style="color: var(--ai-text)">
+            <p>&copy; 2025 Randstad GBS. All Rights Reserved.</p>
+            <p class="text-sm mt-2">AI Horizon Portal | Your guide to the future of work.</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/shared/ai-sme-colors.css
+++ b/shared/ai-sme-colors.css
@@ -1,0 +1,78 @@
+/*
+  AI-SME Website Color Palette
+  This file establishes the standard color scheme for the AI-SME website initiatives.
+  Use these CSS variables to ensure all new and existing pages have a consistent look and feel.
+*/
+
+:root {
+  /* Core Color Palette */
+  --ai-bg: #F8F7F4;          /* soft off-white */
+  --ai-card: #FFFFFF;         /* pure white */
+  --ai-text: #4A4A4A;          /* dark gray */
+  --ai-heading: #111827;      /* darker gray */
+  --ai-accent: #4A90E2;        /* blue */
+  --ai-accent-hover: #357ABD;  /* a slightly darker blue for hover states */
+
+  /* Border & Shadow */
+  --ai-border: #E5E7EB;       /* light gray for borders */
+  --ai-shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+  --ai-shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.07), 0 4px 6px -4px rgba(0, 0, 0, 0.07);
+}
+
+/*
+  Utility Classes
+  Use these classes in your HTML to quickly apply the color scheme.
+  These are provided as a convenience and can be expanded as needed.
+  For more complex components, it is recommended to use the variables directly in your CSS.
+*/
+
+/* Background and Text Colors */
+.bg-ai-background { background-color: var(--ai-bg); }
+.bg-ai-card { background-color: var(--ai-card); }
+.text-ai-text { color: var(--ai-text); }
+.text-ai-heading { color: var(--ai-heading); }
+.text-ai-accent { color: var(--ai-accent); }
+a.text-ai-accent:hover { color: var(--ai-accent-hover); }
+
+/* Buttons */
+.btn-ai-primary {
+  background-color: var(--ai-accent);
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  text-align: center;
+  transition: background-color 0.3s ease;
+}
+.btn-ai-primary:hover {
+  background-color: var(--ai-accent-hover);
+}
+
+.btn-ai-secondary {
+  background-color: transparent;
+  color: var(--ai-accent);
+  border: 1px solid var(--ai-accent);
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  text-align: center;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+.btn-ai-secondary:hover {
+  background-color: var(--ai-accent);
+  color: white;
+}
+
+/* Cards */
+.card-ai {
+  background-color: var(--ai-card);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  border: 1px solid var(--ai-border);
+  box-shadow: var(--ai-shadow-sm);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.card-ai:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--ai-shadow-md);
+}


### PR DESCRIPTION
This commit introduces a centralized and reusable color system for the AI-SME website based on the user's specified palette.

Key changes:
- Creates a new `shared/ai-sme-colors.css` file that defines the color palette using CSS variables (`--ai-bg`, `--ai-accent`, etc.).
- Provides utility classes (`.btn-ai-primary`, `.card-ai`) in the shared CSS for easy application of the new styles.
- Updates `ai-sme/index.html` to link the new stylesheet and use the CSS variables, ensuring the main page conforms to the new design.
- Adds a new `ai-sme/new-page-template.html` file. This serves as a guide for creating new pages, demonstrating how to apply the consistent color scheme to common UI elements like headings, buttons, and cards.

This change addresses the user's request to establish a consistent visual identity that can be easily applied to new pages.