### PR TITLE
Fix tour tooltip overlap issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
             cursor: pointer;
             box-shadow: 0 4px 12px rgba(74, 144, 226, 0.3);
             transition: all 0.3s ease;
-            z-index: 1001;
+            z-index: 1002;
             animation: pulse 2s infinite;
         }
 
@@ -283,7 +283,7 @@
             padding: 24px;
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
             max-width: 320px;
-            z-index: 1001;
+            z-index: 1002;
             opacity: 0;
             transform: scale(0.9);
             transition: all 0.3s ease;
@@ -1186,7 +1186,7 @@
                     padding: 24px;
                     border-radius: 12px;
                     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-                    z-index: 1002;
+                    z-index: 1003;
                     text-align: center;
                     max-width: 320px;
                 `;


### PR DESCRIPTION
The tour tooltip was overlapping with the highlighted element because both had the same z-index. This change increases the z-index of the tooltip and related tour elements to ensure they appear on top.

- Increased z-index for `.tour-button` and `.tour-tooltip` from 1001 to 1002.
- Increased z-index for the completion message from 1002 to 1003 in the `showCompletionMessage` function.

This resolves the visual bug where the tour tooltip was rendered underneath the highlighted tour element.